### PR TITLE
Checkbox appearance vastly improved

### DIFF
--- a/Signals/Signals/App.axaml
+++ b/Signals/Signals/App.axaml
@@ -17,9 +17,11 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceInclude Source="Resources/AppResources.axaml"></ResourceInclude>
                 <ResourceInclude Source="Controls/IconButton.axaml"></ResourceInclude>
+                <ResourceInclude Source="Controls/CheckBox.axaml"></ResourceInclude>
             </ResourceDictionary.MergedDictionaries>
             <converters:UpperCaseConverter x:Key="UpperCaseConverter" />
         </ResourceDictionary>
+        
     </Application.Resources>
 
     <Application.Styles>

--- a/Signals/Signals/Controls/CheckBox.axaml
+++ b/Signals/Signals/Controls/CheckBox.axaml
@@ -1,0 +1,372 @@
+﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    x:ClassModifier="internal">
+    <Design.PreviewWith>
+        <Border Padding="20" Width="350">
+            <Border Classes="main-section">
+                <Grid ColumnDefinitions="*, *">
+                    <StackPanel Spacing="20">
+                        <CheckBox />
+                        <CheckBox IsChecked="True" />
+                        <CheckBox>Unchecked</CheckBox>
+                        <CheckBox IsChecked="True">Checked</CheckBox>
+                        <CheckBox IsThreeState="True" IsChecked="{x:Null}">Indeterminate</CheckBox>
+                        <CheckBox Width="120">Checkbox should wrap its text</CheckBox>
+                    </StackPanel>
+                    <StackPanel Grid.Column="1" Spacing="20">
+                        <CheckBox IsEnabled="False" />
+                        <CheckBox IsEnabled="False" IsChecked="True" />
+                        <CheckBox IsEnabled="False">Unchecked</CheckBox>
+                        <CheckBox IsEnabled="False" IsChecked="True">Checked</CheckBox>
+                        <CheckBox IsEnabled="False" IsThreeState="True" IsChecked="{x:Null}">Indeterminate</CheckBox>
+                        <CheckBox IsEnabled="False" Width="120">Checkbox should wrap its text</CheckBox>
+                    </StackPanel>
+
+                </Grid>
+            </Border>
+        </Border>
+    </Design.PreviewWith>
+
+    <!--
+    ========== IMPORTANT ==========
+    Due to an Avalonia bug, it is not possible to override the checkbox style in the way that we want, so we are 
+    resorting to just copying the source code here and modifying it to suit our needs.
+    -->
+
+    <!--<StreamGeometry x:Key="CheckMarkPathData">M5.5 10.586 1.707 6.793A1 1 0 0 0 .293 8.207l4.5 4.5a1 1 0 0 0 1.414 0l11-11A1 1 0 0 0 15.793.293L5.5 10.586Z</StreamGeometry>-->
+
+    <ControlTheme x:Key="{x:Type CheckBox}" TargetType="CheckBox">
+        <Setter Property="Padding" Value="8,0,0,0" />
+        <Setter Property="HorizontalAlignment" Value="Left" />
+        <Setter Property="VerticalAlignment" Value="Center" />
+        <Setter Property="HorizontalContentAlignment" Value="Left" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+        <Setter Property="MinHeight" Value="32" />
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryForeground}" />
+        <Setter Property="Background" Value="{DynamicResource CheckBoxBackgroundUnchecked}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxBorderGradient}" />
+        <Setter Property="Template">
+            <ControlTemplate>
+                <Grid x:Name="RootGrid" ColumnDefinitions="25,*">
+                    <!--<Border x:Name="PART_Border"
+                            Grid.ColumnSpan="2"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{TemplateBinding CornerRadius}" />
+
+                    Luke recommends not having a border by default, and I agree 
+                    
+                                Background="{DynamicResource CheckBoxCheckBackgroundFillUnchecked}"
+                    -->
+
+                    <Grid VerticalAlignment="Center">
+                        <Border x:Name="NormalRectangle"
+                                BorderBrush="{DynamicResource CheckBoxBorderGradient}"
+                                Background="Transparent"
+                                BorderThickness="{DynamicResource CheckBoxBorderThickness}"
+                                CornerRadius="{TemplateBinding CornerRadius}"
+                                UseLayoutRounding="False"
+                                Height="25"
+                                Width="25" />
+
+                        <Label x:Name="CheckGlyph"
+                               HorizontalAlignment="Center" VerticalAlignment="Center"
+                               Content="&#xEBA6;"
+                               Opacity="0"
+                               Foreground="{DynamicResource PrimaryBackground}"
+                               FontFamily="{DynamicResource PhosphorFill}" />
+
+                        <!-- <Viewbox UseLayoutRounding="False">
+                            <Panel>
+                                <Panel Height="16" Width="16" />
+                                <Path x:Name="CheckGlyph"
+                                      Opacity="0"
+                                      Fill="{DynamicResource CheckBoxCheckGlyphForegroundUnchecked}"
+                                      Stretch="Uniform"
+                                      VerticalAlignment="Center"
+                                      FlowDirection="LeftToRight" />
+                            </Panel>
+                        < /Viewbox>-->
+                    </Grid>
+                    <!-- Normal Unchecked State -->
+                    <ContentPresenter x:Name="PART_ContentPresenter"
+                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                      Content="{TemplateBinding Content}"
+                                      Margin="{TemplateBinding Padding}"
+                                      Foreground="{TemplateBinding Foreground}"
+                                      RecognizesAccessKey="True"
+                                      HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                      VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                      TextWrapping="Wrap"
+                                      Grid.Column="1" />
+                </Grid>
+            </ControlTemplate>
+        </Setter>
+
+        <!-- Unchecked PointerOver State -->
+        <Style Selector="^:pointerover">
+            <!--<Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
+                <Setter Property="Foreground" Value="{DynamicResource CheckBoxForegroundUncheckedPointerOver}" />
+            </Style>-->
+
+            <!--<Style Selector="^ /template/ Border#PART_Border">
+                <Setter Property="Background" Value="{DynamicResource CheckBoxBackgroundUncheckedPointerOver}" />
+                <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushUncheckedPointerOver}" />
+            </Style>-->
+
+            <Style Selector="^ /template/ Border#NormalRectangle">
+                <Setter Property="BorderBrush"
+                        Value="#FF000000" />
+                <!--Value="{DynamicResource CheckBoxCheckBackgroundStrokeUncheckedPointerOver}"-->
+                <Setter Property="Background" Value="{DynamicResource CheckBoxCheckBackgroundFillUncheckedPointerOver}" />
+            </Style>
+
+            <!--<Style Selector="^ /template/ Path#CheckGlyph">
+                <Setter Property="Fill" Value="{DynamicResource CheckBoxCheckGlyphForegroundUncheckedPointerOver}" />
+            </Style>-->
+        </Style>
+
+        <!-- Unchecked Pressed State -->
+        <Style Selector="^:pressed">
+            <!--<Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
+                <Setter Property="Foreground" Value="{DynamicResource CheckBoxForegroundUncheckedPressed}" />
+            </Style>-->
+
+            <!--<Style Selector="^ /template/ Border#PART_Border">
+                <Setter Property="Background" Value="{DynamicResource CheckBoxBackgroundUncheckedPressed}" />
+                <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushUncheckedPressed}" />
+            </Style>-->
+
+            <Style Selector="^ /template/ Border#NormalRectangle">
+                <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxCheckBackgroundStrokeUncheckedPressed}" />
+                <Setter Property="Background" Value="{DynamicResource CheckBoxCheckBackgroundFillUncheckedPressed}" />
+            </Style>
+
+            <Style Selector="^ /template/ Path#CheckGlyph">
+                <Setter Property="Fill" Value="{DynamicResource CheckBoxCheckGlyphForegroundUncheckedPressed}" />
+            </Style>
+        </Style>
+
+        <!-- Unchecked Disabled state -->
+        <Style Selector="^:disabled">
+            <!--<Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
+                <Setter Property="Foreground" Value="{DynamicResource CheckBoxForegroundUncheckedDisabled}" />
+            </Style>-->
+
+            <!--<Style Selector="^ /template/ Border#PART_Border">
+                <Setter Property="Background" Value="{DynamicResource CheckBoxBackgroundUncheckedDisabled}" />
+                <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushUncheckedDisabled}" />
+            </Style>-->
+
+            <Style Selector="^ /template/ Border#NormalRectangle">
+                <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxCheckBackgroundStrokeUncheckedDisabled}" />
+                <Setter Property="Background" Value="{DynamicResource CheckBoxCheckBackgroundFillUncheckedDisabled}" />
+            </Style>
+
+            <Style Selector="^ /template/ Path#CheckGlyph">
+                <Setter Property="Fill" Value="{DynamicResource CheckBoxCheckGlyphForegroundUncheckedDisabled}" />
+            </Style>
+        </Style>
+
+        <Style Selector="^:checked">
+            <!-- Checked Normal State -->
+            <!--<Setter Property="Foreground" Value="{DynamicResource CheckBoxForegroundChecked}" />-->
+            <Setter Property="Background" Value="{DynamicResource PrimaryBackground}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushChecked}" />
+
+            <!--<Style Selector="^ /template/ Border#NormalRectangle">
+                <Setter Property="BorderBrush"
+                        Value="{DynamicResource CheckBoxCheckBackgroundStrokeUncheckedPointerOver}" />
+                ~1~<Setter Property="Background" Value="{DynamicResource CheckBoxCheckBackgroundFillUncheckedPointerOver}" />@1@
+            </Style>-->
+
+            <Style Selector="^ /template/ Border#NormalRectangle">
+                <Setter Property="BorderBrush"
+                        Value="#FF000000" />
+                <!--<Setter Property="BorderBrush" Value="{DynamicResource CheckBoxCheckBackgroundFillChecked}" />-->
+                <Setter Property="Background" Value="{DynamicResource CheckBoxCheckBackgroundFillChecked}" />
+            </Style>
+
+            <Style Selector="^ /template/ Label#CheckGlyph">
+                <!--<Setter Property="Fill" Value="{DynamicResource CheckBoxCheckGlyphForegroundChecked}" />
+                <Setter Property="Data" Value="{StaticResource CheckMarkPathData}" />
+                <Setter Property="Width" Value="9" />-->
+                <Setter Property="Opacity" Value="1" />
+            </Style>
+
+            <!-- Checked PointerOver State -->
+            <Style Selector="^:pointerover">
+                <!--<Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
+                    <Setter Property="Foreground" Value="{DynamicResource CheckBoxForegroundCheckedPointerOver}" />
+                </Style>-->
+
+                <!--<Style Selector="^ /template/ Border#PART_Border">
+                    <Setter Property="Background" Value="{DynamicResource CheckBoxBackgroundCheckedPointerOver}" />
+                    <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushCheckedPointerOver}" />
+                </Style>-->
+
+                <Style Selector="^ /template/ Border#NormalRectangle">
+                    <Setter Property="BorderBrush"
+                            Value="{DynamicResource CheckBoxCheckBackgroundStrokeCheckedPointerOver}" />
+                    <Setter Property="Background"
+                            Value="{DynamicResource CheckBoxCheckBackgroundFillCheckedPointerOver}" />
+                </Style>
+
+                <Style Selector="^ /template/ Path#CheckGlyph">
+                    <Setter Property="Fill" Value="{DynamicResource CheckBoxCheckGlyphForegroundCheckedPointerOver}" />
+                </Style>
+            </Style>
+
+            <!-- Checked Pressed State -->
+            <Style Selector="^:pressed">
+                <!--<Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
+                    <Setter Property="Foreground" Value="{DynamicResource CheckBoxForegroundCheckedPressed}" />
+                </Style>-->
+
+                <!--<Style Selector="^ /template/ Border#PART_Border">
+                    <Setter Property="Background" Value="{DynamicResource CheckBoxBackgroundCheckedPressed}" />
+                    <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushCheckedPressed}" />
+                </Style>-->
+
+                <Style Selector="^ /template/ Border#NormalRectangle">
+                    <Setter Property="BorderBrush"
+                            Value="{DynamicResource CheckBoxCheckBackgroundStrokeCheckedPressed}" />
+                    <Setter Property="Background" Value="{DynamicResource CheckBoxCheckBackgroundFillCheckedPressed}" />
+                </Style>
+
+                <Style Selector="^ /template/ Path#CheckGlyph">
+                    <Setter Property="Fill" Value="{DynamicResource CheckBoxCheckGlyphForegroundCheckedPressed}" />
+                </Style>
+            </Style>
+
+            <!-- Checked Disabled State -->
+            <Style Selector="^:checked:disabled">
+                <!--<Style Selector="^ ContentPresenter#PART_ContentPresenter">
+                    <Setter Property="Foreground" Value="{DynamicResource CheckBoxForegroundCheckedDisabled}" />
+                </Style>-->
+
+                <!--<Style Selector="^ /template/ Border#PART_Border">
+                    <Setter Property="Background" Value="{DynamicResource CheckBoxBackgroundCheckedDisabled}" />
+                    <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushCheckedDisabled}" />
+                </Style>-->
+
+                <Style Selector="^ /template/ Border#NormalRectangle">
+                    <Setter Property="BorderBrush"
+                            Value="#FF888888" />
+                    <!--Value="{DynamicResource CheckBoxCheckBackgroundStrokeCheckedDisabled}"-->
+                    <Setter Property="Background" Value="{DynamicResource CheckBoxCheckBackgroundFillCheckedDisabled}" />
+                </Style>
+
+                <Style Selector="^ /template/ Path#CheckGlyph">
+                    <Setter Property="Fill" Value="{DynamicResource CheckBoxCheckGlyphForegroundCheckedDisabled}" />
+                </Style>
+            </Style>
+        </Style>
+
+        <Style Selector="^:indeterminate">
+            <!-- Indeterminate Normal State -->
+            <!--<Setter Property="Foreground" Value="{DynamicResource CheckBoxForegroundIndeterminate}" />
+            <Setter Property="Background" Value="{DynamicResource CheckBoxBackgroundIndeterminate}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushIndeterminate}" />-->
+
+            <Style Selector="^ /template/ Border#NormalRectangle">
+                <Setter Property="BorderBrush"
+                        Value="#FF888888" />
+                <!--Value="{DynamicResource CheckBoxBorderGradient}"-->
+                <Setter Property="Background" Value="{DynamicResource CheckBoxCheckBackgroundFillIndeterminate}" />
+            </Style>
+
+            <!--<Style Selector="^ /template/ Path#CheckGlyph">-->
+            <Style Selector="^ /template/ Label#CheckGlyph">
+                <!--<Setter Property="Fill" Value="{DynamicResource CheckBoxCheckGlyphForegroundIndeterminate}" />
+                <Setter Property="Data" Value="M1536 1536v-1024h-1024v1024h1024z" />-->
+                <Setter Property="Content" Value="&#xe1ec;"></Setter>
+                <!--<Setter Property="Width" Value="7" />-->
+                <Setter Property="Opacity" Value="1" />
+            </Style>
+
+            <!-- Indeterminate PointerOver State -->
+            <Style Selector="^:pointerover">
+                <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
+                    <Setter Property="Foreground" Value="{DynamicResource CheckBoxForegroundIndeterminatePointerOver}" />
+                </Style>
+
+                <Style Selector="^ /template/ Border#PART_Border">
+                    <!--<Setter Property="Background" Value="{DynamicResource CheckBoxBackgroundIndeterminatePointerOver}" />-->
+                    <Setter Property="BorderBrush"
+                            Value="#FF888888" />
+                    <!--Value="{DynamicResource CheckBoxCheckBackgroundStrokeUncheckedPointerOver}"-->
+
+                </Style>
+
+                <Style Selector="^ /template/ Border#NormalRectangle">
+                    <Setter Property="BorderBrush"
+                            Value="{DynamicResource CheckBoxCheckBackgroundStrokeIndeterminatePointerOver}" />
+                    <Setter Property="Background"
+                            Value="{DynamicResource CheckBoxCheckBackgroundFillIndeterminatePointerOver}" />
+                </Style>
+
+                <Style Selector="^ /template/ Path#CheckGlyph">
+                    <Setter Property="Fill"
+                            Value="{DynamicResource CheckBoxCheckGlyphForegroundIndeterminatePointerOver}" />
+                </Style>
+            </Style>
+
+            <!-- Indeterminate Pressed State -->
+            <Style Selector="^:pressed">
+                <!--<Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
+                    <Setter Property="Foreground" Value="{DynamicResource CheckBoxForegroundIndeterminatePressed}" />
+                </Style>-->
+
+                <!--<Style Selector="^ /template/ Border#PART_Border">
+                    <Setter Property="Background" Value="{DynamicResource CheckBoxBackgroundIndeterminatePressed}" />
+                    <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushIndeterminatePressed}" />
+                </Style>-->
+
+                <Style Selector="^ /template/ Border#NormalRectangle">
+                    <Setter Property="BorderBrush"
+                            Value="{DynamicResource CheckBoxCheckBackgroundStrokeIndeterminatePressed}" />
+                    <Setter Property="Background"
+                            Value="{DynamicResource CheckBoxCheckBackgroundFillIndeterminatePressed}" />
+                </Style>
+
+                <Style Selector="^ /template/ Path#CheckGlyph">
+                    <Setter Property="Fill" Value="{DynamicResource CheckBoxCheckGlyphForegroundIndeterminatePressed}" />
+                </Style>
+            </Style>
+
+            <!-- Indeterminate Disabled State -->
+            <Style Selector="^:disabled">
+                <!--<Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
+                    <Setter Property="Foreground" Value="{DynamicResource CheckBoxForegroundIndeterminateDisabled}" />
+                </Style>-->
+
+                <!--<Style Selector="^ /template/ Border#PART_Border">
+                    <Setter Property="Background" Value="{DynamicResource CheckBoxBackgroundIndeterminateDisabled}" />
+                    <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushIndeterminateDisabled}" />
+                </Style>-->
+
+                <Style Selector="^ /template/ Border#NormalRectangle">
+                    <Setter Property="BorderBrush" Value="#FF888888"></Setter>
+
+                    <!--<Setter Property="BorderBrush"
+                            Value="{DynamicResource CheckBoxCheckBackgroundStrokeIndeterminateDisabled}" />-->
+                    <Setter Property="Background"
+                            Value="{DynamicResource CheckBoxCheckBackgroundFillIndeterminateDisabled}" />
+                </Style>
+
+                <Style Selector="^ /template/ Path#CheckGlyph">
+                    <Setter Property="Fill" Value="{DynamicResource CheckBoxCheckGlyphForegroundIndeterminateDisabled}" />
+                </Style>
+
+                <!-- Indeterminate Disabled Checked State -->
+                <Style Selector="^:checked">
+                    <Setter Property="BorderBrush" Value="#FF888888"></Setter>
+                </Style>
+
+            </Style>
+        </Style>
+    </ControlTheme>
+</ResourceDictionary>

--- a/Signals/Signals/Resources/AppResources.axaml
+++ b/Signals/Signals/Resources/AppResources.axaml
@@ -2,20 +2,58 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
     <!-- Add Resources Here -->
-    
-    <Color x:Key="PrimaryForeground">CadetBlue</Color>
-    <Color x:Key="PrimaryBackground">Black</Color>
-    
-    <Color x:Key="MainSectionBackground">WhiteSmoke</Color>
-    <Color x:Key="WindowBackground">SteelBlue</Color>
-    <Color x:Key="WindowBackground1">#FFA9BCCF</Color>
     <!--
     <Color x:Key="WindowBackgroundp00">#EFAABED0</Color>
     -->
-    <Color x:Key="PrimaryPageForeground">Black</Color>
     
+    <Color x:Key="PrimaryForeground">CadetBlue</Color>
+    <Color x:Key="PrimaryBackground">Black</Color>
     <Color x:Key="PrimaryHoverForeground">DodgerBlue</Color>
     <Color x:Key="PrimaryHoverBackground">WhiteSmoke</Color>
+
+    <Color x:Key="BuyButtonForeground">WhiteSmoke</Color>
+    <Color x:Key="BuyButtonBackground">Green</Color>
+    <Color x:Key="BuyButtonHoverForeground">Black</Color>
+    <Color x:Key="BuyButtonHoverBackground">LightGreen</Color>
+
+    <Color x:Key="SellButtonForeground">WhiteSmoke</Color>
+    <Color x:Key="SellButtonBackground">Red</Color>
+    <Color x:Key="SellButtonHoverForeground">Black</Color>
+    <Color x:Key="SellButtonHoverBackground"> LightPink</Color>
+
+    <Color x:Key="CommandButtonForeground">WhiteSmoke</Color>
+    <Color x:Key="CommandButtonBackground">Black</Color>
+    <Color x:Key="CommandButtonHoverForeground">Black</Color>
+    <Color x:Key="CommandButtonHoverBackground"> LightSlateGray</Color>
+    
+    <Color x:Key="CheckBoxBorderColor">Black</Color>
+    <Thickness x:Key="CheckBoxBorderThickness">3</Thickness>
+    <CornerRadius x:Key="CheckBoxCornerRadius">30</CornerRadius>
+    
+    <Color x:Key="MainSectionBackground">AntiqueWhite</Color>
+    <Color x:Key="WindowBackground">SteelBlue</Color>
+    <Color x:Key="WindowBackground1">#FFA9BCCF</Color>
+    <Color x:Key="PrimaryPageForeground">Black</Color>
+    
+    <LinearGradientBrush x:Key="CheckBoxBorderGradient" StartPoint="0%, 0%" EndPoint="100%, 0%">
+        <GradientStop Offset="0" Color="Black"></GradientStop>
+        <GradientStop Offset="1" Color="DimGray"></GradientStop>
+    </LinearGradientBrush>
+    
+    <LinearGradientBrush x:Key="CommandButtonBackgroundGradient" StartPoint="0%, 0%" EndPoint="100%, 0%">
+        <GradientStop Offset="0" Color="Black"></GradientStop>
+        <GradientStop Offset="1" Color="LightSlateGray"></GradientStop>
+    </LinearGradientBrush>
+    
+    <LinearGradientBrush x:Key="BuyButtonBackgroundGradient" StartPoint="0%, 0%" EndPoint="100%, 0%">
+        <GradientStop Offset="0" Color="Green"></GradientStop>
+        <GradientStop Offset="1" Color="LightGreen"></GradientStop>
+    </LinearGradientBrush>
+    
+    <LinearGradientBrush x:Key="SellButtonBackgroundGradient" StartPoint="0%, 0%" EndPoint="100%, 0%">
+        <GradientStop Offset="0" Color="Red"></GradientStop>
+        <GradientStop Offset="1" Color="LightPink"></GradientStop>
+    </LinearGradientBrush>
     
     <Color x:Key="ItemBorder"> DarkGray</Color>
     <Color x:Key="NumericColor">#7777ee</Color>

--- a/Signals/Signals/Resources/Resources.Designer.cs
+++ b/Signals/Signals/Resources/Resources.Designer.cs
@@ -265,5 +265,14 @@ namespace Signals.Resources {
                 return ResourceManager.GetString("TagLine", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use.
+        /// </summary>
+        public static string Use {
+            get {
+                return ResourceManager.GetString("Use", resourceCulture);
+            }
+        }
     }
 }

--- a/Signals/Signals/Resources/Resources.resx
+++ b/Signals/Signals/Resources/Resources.resx
@@ -25,6 +25,9 @@
     <data name="TagLine" xml:space="preserve">
         <value>Watch what happens</value>
     </data>
+    <data name="Use" xml:space="preserve">
+        <value>Use</value>
+    </data>
     <data name="BtnBackupDatabaseContent" xml:space="preserve">
         <value>Backup Database</value>
     </data>

--- a/Signals/Signals/Signals.csproj
+++ b/Signals/Signals/Signals.csproj
@@ -18,6 +18,7 @@
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
         <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.2.7" />
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+        <PackageReference Include="MessageBox.Avalonia" Version="3.2.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.4" />
         <PackageReference Include="sqlite-net-pcl" Version="1.9.172" />
         <PackageReference Include="System.Text.Json" Version="9.0.4" />

--- a/Signals/Signals/Styles/AppDefaultStyles.axaml
+++ b/Signals/Signals/Styles/AppDefaultStyles.axaml
@@ -1,21 +1,42 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Design.PreviewWith>
-        <Border Padding="20">
-            <!-- Add Controls for Previewer Here -->
-            <StackPanel>
-                <Button>
-                    <StackPanel Orientation="Horizontal">
-                        <Label Classes="icon" Content="&#xea8c;"></Label>
-                        <Label Content=" Button"></Label>
+        <Border Padding="20" Width="400">
+            <!-- Background="{DynamicResource MainSectionBackground} -->
+            <Border Classes="main-section" >
+                <Grid ColumnDefinitions="*, *">
+                    <!-- Add Controls for Previewer Here -->
+                    <StackPanel>
+                        <Button>
+                            <StackPanel Orientation="Horizontal">
+                                <Label Classes="icon" Content="&#xea8c;"></Label>
+                                <Label Content=" Button"></Label>
+                            </StackPanel>
+                        </Button>
+                        <Button Classes="command">
+                            <StackPanel Orientation="Horizontal">
+                                <Label Content=" Button"></Label>
+                            </StackPanel>
+                        </Button>
+                        <Button Classes="buy">
+                            <StackPanel Orientation="Horizontal">
+                                <Label Content=" Buy"></Label>
+                            </StackPanel>
+                        </Button>
+                        <Button Classes="sell">
+                            <StackPanel Orientation="Horizontal">
+                                <Label Content=" Sell"></Label>
+                            </StackPanel>
+                        </Button>
                     </StackPanel>
-                </Button>
-                <Button Classes="command">
-                    <StackPanel Orientation="Horizontal">
-                        <Label Content=" Button"></Label>
+                    <StackPanel Grid.Column="1" Spacing="15">
+                        <CheckBox></CheckBox>
+                        <CheckBox>Has Content</CheckBox>
+                        <Label Foreground="{DynamicResource PrimaryForeground}">Label</Label>
+                        <TextBox>Text</TextBox>
                     </StackPanel>
-                </Button>
-            </StackPanel>
+                </Grid>
+            </Border>
         </Border>
     </Design.PreviewWith>
 
@@ -38,6 +59,8 @@
         <Setter Property="FontFamily" Value="{DynamicResource  DefaultFontFamily}"></Setter>
         <Setter Property="Background" Value="{DynamicResource WindowBackground}"></Setter>
     </Style>
+
+    <!-- Label Styles -->
 
     <Style Selector="Label">
         <Setter Property="FontWeight" Value="SemiBold"></Setter>
@@ -68,6 +91,8 @@
         <Setter Property="RenderTransform" Value="scale(1.2)"></Setter>
     </Style>
 
+    <!-- TextBlock Styles -->
+
     <Style Selector="TextBlock">
         <Setter Property="Padding" Value="5,5,5,0"></Setter>
         <Setter Property="TextWrapping" Value="Wrap"></Setter>
@@ -84,12 +109,6 @@
         <Setter Property="Foreground" Value="Black"></Setter>
         <Setter Property="HorizontalAlignment" Value="Right"></Setter>
         <Setter Property="TextWrapping" Value="WrapWithOverflow"></Setter>
-    </Style>
-
-    <Style Selector="Border.header">
-        <Setter Property="Padding" Value="10"></Setter>
-        <Setter Property="Background" Value="Black"></Setter>
-        <Setter Property="CornerRadius" Value="10, 10, 0, 0"></Setter>
     </Style>
 
     <Style Selector="TextBlock.page-title">
@@ -113,7 +132,7 @@
         <Setter Property="HorizontalAlignment" Value="Right"></Setter>
     </Style>
 
-    <!-- Text Boxes -->
+    <!-- TextBox Styles -->
 
     <Style Selector="TextBox">
         <Setter Property="Foreground" Value="{DynamicResource PrimaryForeground}"></Setter>
@@ -122,31 +141,28 @@
         <Setter Property="BorderThickness" Value="1"></Setter>
         <Setter Property="CornerRadius" Value="0"></Setter>
     </Style>
-    
+
     <Style Selector="TextBox:disabled /template/ Border#PART_BorderElement">
         <Setter Property="BorderBrush" Value="{DynamicResource PrimaryForeground}"></Setter>
         <Setter Property="BorderThickness" Value="1 1 0 1"></Setter>
     </Style>
-    
+
     <Style Selector="TextBox.number-field">
-        <Setter Property="Width" Value="50"></Setter>
+        <!--<Setter Property="Width" Value="50"></Setter>-->
+        <Setter Property="Margin" Value="5 0"></Setter>
         <Setter Property="TextAlignment" Value="Right"></Setter>
     </Style>
-    
-    <Style Selector="CheckBox">
-        <Setter Property="IsVisible" Value="True"></Setter>
-        <Setter Property="BorderThickness" Value="1"></Setter>
-        <Setter Property="BorderBrush" Value="Blue"></Setter>
-    </Style>
-    
-    <Style Selector=":is(Button)">
+
+    <!-- Button Styles -->
+
+    <Style Selector=":is(Button):not(CheckBox)">
         <Setter Property="Margin" Value="0 5 5 0"></Setter>
         <Setter Property="FontSize" Value="16"></Setter>
         <Setter Property="CornerRadius" Value="5"></Setter>
         <Setter Property="Foreground" Value="{DynamicResource PrimaryForeground}"></Setter>
         <Setter Property="Background" Value="{DynamicResource PrimaryBackground}"></Setter>
     </Style>
-    
+
     <Style Selector=":is(Button):disabled /template/ ContentPresenter">
         <Setter Property="Background" Value="{DynamicResource SystemChromeGrayColor}"></Setter>
     </Style>
@@ -154,14 +170,14 @@
     <Style Selector=":is(Button) /template/ ContentPresenter">
         <Setter Property="Transitions">
             <Transitions>
-                <BrushTransition Property="Foreground" Duration="0:0:0.5"></BrushTransition>
-                <BrushTransition Property="Background" Duration="0:0:0.5"></BrushTransition>
+                <BrushTransition Property="Foreground" Duration="0:0:0.3"></BrushTransition>
+                <BrushTransition Property="Background" Duration="0:0:0.3"></BrushTransition>
                 <TransformOperationsTransition Property="RenderTransform" Duration="0:0:0.2"></TransformOperationsTransition>
             </Transitions>
         </Setter>
     </Style>
 
-    <Style Selector=":is(Button):pointerover /template/ ContentPresenter">
+    <Style Selector=":is(Button):not(CheckBox):pointerover /template/ ContentPresenter">
         <Setter Property="Foreground" Value="{DynamicResource PrimaryHoverForeground}"></Setter>
         <Setter Property="Background" Value="LightSteelBlue"></Setter>
     </Style>
@@ -171,6 +187,7 @@
         <Setter Property="Background" Value="{DynamicResource ButtonBackground}"></Setter>
         <Setter Property="BorderBrush" Value="{DynamicResource PrimaryForeground}"></Setter>
         <Setter Property="Margin" Value="0 0 0 0"></Setter>
+        <Setter Property="CornerRadius" Value="0"></Setter>
     </Style>
 
     <Style Selector=":is(Button).decorator:pointerover /template/ ContentPresenter">
@@ -189,11 +206,58 @@
     </Style>
 
     <Style Selector=":is(Button).command">
-        <Setter Property="Padding" Value="5  20 0 20"></Setter>
-        <Setter Property="HorizontalAlignment" Value="Stretch" ></Setter>
+        <Setter Property="Padding" Value="5"></Setter>
         <Setter Property="HorizontalContentAlignment" Value="Center"></Setter>
+        <Setter Property="Foreground" Value="{DynamicResource CommandButtonForeground}"></Setter>
+        <Setter Property="Background" Value="{DynamicResource CommandButtonBackgroundGradient}"></Setter>
     </Style>
 
+    <Style Selector=":is(Button).command:pointerover /template/ ContentPresenter">
+        <Setter Property="Padding" Value="5"></Setter>
+        <Setter Property="HorizontalContentAlignment" Value="Center"></Setter>
+        <Setter Property="Foreground" Value="{DynamicResource CommandButtonHoverForeground}"></Setter>
+        <Setter Property="Background" Value="{DynamicResource CommandButtonHoverBackground}"></Setter>
+    </Style>
+
+    <Style Selector=":is(Button).buy">
+        <Setter Property="Padding" Value="5"></Setter>
+        <Setter Property="HorizontalContentAlignment" Value="Center"></Setter>
+        <Setter Property="Foreground" Value="{DynamicResource BuyButtonForeground}"></Setter>
+        <Setter Property="Background" Value="{DynamicResource BuyButtonBackgroundGradient}"></Setter>
+    </Style>
+
+    <Style Selector=":is(Button).buy:pointerover /template/ ContentPresenter">
+        <Setter Property="Foreground" Value="{DynamicResource BuyButtonHoverForeground}"></Setter>
+        <Setter Property="Background" Value="{DynamicResource BuyButtonHoverBackground}"></Setter>
+    </Style>
+
+    <Style Selector=":is(Button).sell">
+        <Setter Property="Padding" Value="5"></Setter>
+        <Setter Property="HorizontalContentAlignment" Value="Center"></Setter>
+        <Setter Property="Background" Value="{DynamicResource SellButtonBackgroundGradient}"></Setter>
+        <Setter Property="Foreground" Value="{DynamicResource SellButtonForeground}"></Setter>
+    </Style>
+
+    <Style Selector=":is(Button).sell:pointerover /template/ ContentPresenter">
+        <Setter Property="Foreground" Value="{DynamicResource SellButtonHoverForeground}"></Setter>
+        <Setter Property="Background" Value="{DynamicResource SellButtonHoverBackground}"></Setter>
+    </Style>
+
+    <!--Border Styles-->
+    
+    <Style Selector="Border.app-header">
+        <Setter Property="Padding" Value="10"></Setter>
+        <Setter Property="Background" Value="Black"></Setter>
+        <Setter Property="CornerRadius" Value="10, 10, 0, 0"></Setter>
+    </Style>
+
+    <Style Selector="Border.main-section">
+        <!-- a bit of margin to correct for an apparent rendering bug (or perhaps an optical illusion) due to the coloring -->
+        <Setter Property="Margin" Value="0.9 0 0.9 0"></Setter>
+        <Setter Property="Padding" Value="5"></Setter>
+        <Setter Property="Background" Value="{DynamicResource MainSectionBackground}"></Setter>
+    </Style>
+    
     <Style Selector="Border.item-border">
         <Setter Property="BorderBrush" Value="{DynamicResource ItemBorder}"></Setter>
         <Setter Property="BorderThickness" Value="0, 0, 0, 1"></Setter>
@@ -205,16 +269,18 @@
         <Setter Property="Padding" Value="5"></Setter>
         <Setter Property="CornerRadius" Value="10"></Setter>
     </Style>
-    
+
     <Style Selector="Border.footer">
         <Setter Property="CornerRadius" Value="0, 0, 10, 10"></Setter>
     </Style>
 
+    <!--Grid Styles-->
     <Style Selector="Grid.heading">
         <Setter Property="Background" Value="LightGray"></Setter>
     </Style>
 
-    <Style Selector="StackPanel.formfield">
+    <!--StackPanel Styles-->
+    <Style Selector="StackPanel.formField">
         <Setter Property="Margin" Value="0 5 0 0"></Setter>
     </Style>
 

--- a/Signals/Signals/ViewModels/WatchlistItemPageViewModel.cs
+++ b/Signals/Signals/ViewModels/WatchlistItemPageViewModel.cs
@@ -1,7 +1,10 @@
 ﻿using System.Threading.Tasks;
 using AutoMapper;
+using Avalonia.Controls;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using MsBox.Avalonia;
+using MsBox.Avalonia.Enums;
 using Signals.ApplicationLayer.Abstract;
 using Signals.CoreLayer.Entities;
 using Signals.Factories;
@@ -34,6 +37,22 @@ public partial class WatchlistItemPageViewModel : PageViewModel
     public async Task LoadData(string symbol)
     {
         WatchlistItem = await WatchlistService.GetBySymbol(symbol);
+    }
+
+    [RelayCommand]
+    public async Task DeleteWatchlistItem()
+    {
+        var box = MessageBoxManager
+            .GetMessageBoxStandard("Delete", "Are you sure you would like to delete this watchlist item?",
+                ButtonEnum.YesNo, 
+                Icon.Question,
+                WindowStartupLocation.CenterOwner);
+
+        var result = await box.ShowAsync();
+        if (result == ButtonResult.Yes)
+        {
+            // delete the current item
+        }
     }
     
 }

--- a/Signals/Signals/Views/AddItemPageView.axaml
+++ b/Signals/Signals/Views/AddItemPageView.axaml
@@ -22,12 +22,12 @@
             <TextBox Text="{Binding Symbol, Converter={StaticResource UpperCaseConverter}}"></TextBox>
         </StackPanel>
         
-        <StackPanel Classes="formfield" Orientation="Horizontal">
+        <StackPanel Classes="formField" Orientation="Horizontal">
             <CheckBox IsChecked="{Binding AddToWatchlist}"></CheckBox>
             <Label Content="{x:Static lang:Resources.AddToWatchlistLabel}"></Label>
         </StackPanel>
         
-        <StackPanel Classes="formfield" Orientation="Horizontal">
+        <StackPanel Classes="formField" Orientation="Horizontal">
             <CheckBox IsChecked="{Binding AddToHoldings}"></CheckBox>
             <Label Content="{x:Static lang:Resources.AddToHoldingsLabel}"></Label>
         </StackPanel>

--- a/Signals/Signals/Views/HoldingsItemPageView.axaml
+++ b/Signals/Signals/Views/HoldingsItemPageView.axaml
@@ -38,14 +38,21 @@
                                 <TextBlock
                                     Text="{Binding  WhenLatestQuoteReceived, StringFormat={}{0:MMM d\, yyyy hh:mm tt}}" />
 
-                                <Grid RowDefinitions="Auto, Auto, Auto, Auto, Auto, Auto" ColumnDefinitions="*,*">
-
+                                <Grid RowDefinitions="Auto, Auto, Auto, Auto, Auto, Auto" ColumnDefinitions="*,5,*">
+                                    <Grid.Styles>
+                                        <Style Selector="TextBlock">
+                                            <Setter Property="Margin" Value="0 0 8 0"></Setter>
+                                        </Style>
+                                        <Style Selector="TextBox">
+                                            <Setter Property="Margin" Value="0 0 8 0"></Setter>
+                                        </Style>
+                                    </Grid.Styles>
                                     <StackPanel Grid.Row="0" Grid.Column="0">
                                         <Label Content="Latest Quote" />
                                         <TextBlock Text="{Binding  LatestQuotedPrice, StringFormat={}{0:C}}" />
                                     </StackPanel>
 
-                                    <StackPanel Grid.Row="0" Grid.Column="1">
+                                    <StackPanel Grid.Row="0" Grid.Column="2">
                                         <Label Content="% Change" />
                                         <TextBlock
                                             Text="{Binding  CurrentDayPercentChange, StringFormat={}{0:#0.0%}}" />
@@ -56,7 +63,7 @@
                                         <TextBlock Text="{Binding  PreviousDayClosingPrice, StringFormat={}{0:C}}" />
                                     </StackPanel>
 
-                                    <StackPanel Grid.Row="1" Grid.Column="1">
+                                    <StackPanel Grid.Row="1" Grid.Column="2">
                                         <Label Content="Today's Open" />
                                         <TextBlock Text="{Binding  CurrentDayOpeningPrice, StringFormat={}{0:C}}" />
                                     </StackPanel>
@@ -66,7 +73,7 @@
                                         <TextBlock Text="{Binding  CurrentDayLowPrice, StringFormat={}{0:C}}" />
                                     </StackPanel>
 
-                                    <StackPanel Grid.Row="2" Grid.Column="1">
+                                    <StackPanel Grid.Row="2" Grid.Column="2">
                                         <Label Content="Daily High" />
                                         <TextBlock Text="{Binding  CurrentDayHighPrice, StringFormat={}{0:C}}" />
                                     </StackPanel>
@@ -77,7 +84,7 @@
                                             Text="{Binding  WhenPurchased, StringFormat={}{0:MMM d\, yyyy hh:mm tt}}" />
                                     </StackPanel>
 
-                                    <StackPanel Grid.Row="3" Grid.Column="1">
+                                    <StackPanel Grid.Row="3" Grid.Column="2">
                                         <Label Content="Number of Units Held" />
                                         <TextBox Text="{Binding  QuantityHeld, StringFormat={}{0:#0}}" />
                                     </StackPanel>
@@ -92,7 +99,7 @@
                                         <TextBox Text="{Binding  HighTargetPrice, StringFormat={}{0:C}}" />
                                     </StackPanel>
 
-                                    <StackPanel Grid.Row="5" Grid.Column="1">
+                                    <StackPanel Grid.Row="5" Grid.Column="2">
                                         <Label Content="Low Target Price" />
                                         <TextBox Text="{Binding  LowTargetPrice, StringFormat={}{0:C}}" />
                                     </StackPanel>
@@ -111,8 +118,8 @@
             </ContentControl.ContentTemplate>
         </ContentControl>
         <StackPanel Grid.Row="1" Orientation="Horizontal">
-            <IconButton IconText="&#xeb48;" Content="Buy"></IconButton>
-            <IconButton IconText="&#xe478;" Content="Sell"></IconButton>
+            <IconButton Classes="buy" IconText="&#xeb48;" Content="Buy"></IconButton>
+            <IconButton Classes="sell" IconText="&#xe478;" Content="Sell"></IconButton>
         </StackPanel>
     </Grid>
 </UserControl>

--- a/Signals/Signals/Views/MainView.axaml
+++ b/Signals/Signals/Views/MainView.axaml
@@ -14,11 +14,13 @@
     <!-- Note: Using icon fonts from https://phosphoricons.com/ for certain icons -->
     <Grid RowDefinitions="Auto, *, Auto" Margin="20">
         
-        <!-- Top Bar: Contains App Title and subtitle -->
+        <!-- Top Bar: Contains App Title and tagline ($ignalS Watch what happens) -->
         <StackPanel Grid.Row="0">
             <TextBlock Classes="title" Text="{x:Static lang:Resources.AppTitle}" />
             <TextBlock Classes="tag-line" Text="{x:Static lang:Resources.TagLine}" />
-            <Border Classes="header">
+            
+            <!-- App Content Container Border -->
+            <Border Classes="app-header">
                 <Grid ColumnDefinitions="*, Auto">
                     <TextBlock Grid.Column="0" Classes="page-title" FontSize="24" Text="{Binding PageTitle}" />
                     <!-- Add button - brings up the dialog to add a new StockItem -->
@@ -51,7 +53,7 @@
         </StackPanel>
 
         <!-- Main part -->
-        <Border Grid.Row="1" Background="{DynamicResource MainSectionBackground}">
+        <Border Grid.Row="1" Classes="main-section">
             <Grid>
                 <ContentControl Content="{Binding CurrentPage}"
                                 Foreground="{DynamicResource PrimaryForeground}"

--- a/Signals/Signals/Views/SettingsPageView.axaml
+++ b/Signals/Signals/Views/SettingsPageView.axaml
@@ -11,91 +11,98 @@
     <Design.DataContext>
         <vm:SettingsPageViewModel />
     </Design.DataContext>
-
-    <Grid RowDefinitions="Auto, *">
+    <Grid RowDefinitions="Auto, *, Auto">
         <Label Grid.Row="0" Classes="heading" Content="{Binding PageSubtitle}"></Label>
 
-        <Grid Grid.Row="1" RowDefinitions="Auto, Auto, Auto, *, Auto" ColumnDefinitions="Auto, *"
-              ShowGridLines="True">
-            
-            <StackPanel Classes="formfield" Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal">
-                <Label Content="{x:Static lang:Resources.SettingsMetadataVersionLabel}"></Label>
-                <TextBlock Text="{Binding MetadataVersion}"></TextBlock>
-            </StackPanel>
+        <Grid Grid.Row="1" RowDefinitions="Auto, Auto, Auto, *, Auto" ColumnDefinitions="Auto, 16, *">
 
-             <!-- Default Gain Alert Level -->
-            <StackPanel Classes="formfield" Grid.Row="1" Grid.Column="0" HorizontalAlignment="Stretch">
+            <Label Content="{x:Static lang:Resources.SettingsMetadataVersionLabel}"></Label>
+            <TextBlock Grid.Row="0" Grid.Column="2" Text="{Binding MetadataVersion}"></TextBlock>
+
+            <!-- Default Gain Alert Level -->
+            <StackPanel Classes="formField" Grid.Row="1" Grid.Column="0" HorizontalAlignment="Stretch">
                 <Label Content="{x:Static lang:Resources.SettingsDefaultHighGainMultiplierLabel}" />
                 <TextBox Classes="number-field" Text="{Binding SettingsDefaultHighGainMultiplier}" />
             </StackPanel>
 
             <!-- Use Gain Alert -->
-            <StackPanel Classes="formfield" Grid.Row="1" Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Bottom">
-                <CheckBox IsChecked="{Binding SettingsDefaultUseHighGainMultiplier}"></CheckBox>
-                <Label Content="{x:Static lang:Resources.SettingsDefaultUseHighGainMultiplierLabel}"></Label>
+            <StackPanel Classes="formField" Grid.Row="1" Grid.Column="2" Orientation="Horizontal"
+                        VerticalAlignment="Bottom">
+                <CheckBox Content="{x:Static lang:Resources.Use}"
+                          IsChecked="{Binding SettingsDefaultUseHighGainMultiplier}">
+                </CheckBox>
+                <!--<Label 
+                    Content="{x:Static lang:Resources.SettingsDefaultUseHighGainMultiplierLabel}"></Label>-->
             </StackPanel>
 
-             <!-- Default Trailing Stop --> 
-            <StackPanel Classes="formfield" Grid.Row="2" Grid.Column="0" HorizontalAlignment="Stretch">
+            <!-- Default Trailing Stop -->
+            <StackPanel Classes="formField" Grid.Row="2" Grid.Column="0" HorizontalAlignment="Stretch">
                 <Label Content="{x:Static lang:Resources.SettingsDefaultTrailingStopLabel}" />
                 <TextBox Classes="number-field" Text="{Binding SettingsDefaultTrailingStop}" />
             </StackPanel>
 
-             <!-- Use Trailing Stop --> 
-            <StackPanel Classes="formfield" Grid.Row="2" Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Bottom">
-                <CheckBox IsChecked="{Binding SettingsDefaultUseTrailingStop}" />
-                <Label Content="{x:Static lang:Resources.SettingsDefaultUseTrailingStopLabel}" />
-            </StackPanel>
-             
-             <StackPanel Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"></StackPanel>
-
-            <StackPanel Classes="formfield" Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2">
-                <StackPanel.Styles>
-                    <Style Selector="TextBox">
-                        <Setter Property="BorderBrush" Value="{DynamicResource PrimaryForeground}"></Setter>
-                        <Setter Property="BorderThickness" Value="1 1 0 1"></Setter>
-                    </Style>
-                </StackPanel.Styles>
-                <Label Content="{x:Static lang:Resources.KeyLabel}"></Label>
-                <Grid ColumnDefinitions="*, Auto" Classes="formfield">
-                    <TextBox Name="TokenInput" Text="{Binding Key}"
-                             IsEnabled="{Binding  KeyIsInEditMode}"
-                             HorizontalAlignment="Stretch" MaxLength="25" />
-                    <StackPanel Grid.Column="1" Orientation="Horizontal">
-
-                        <Button Classes="decorator"
-                                Command="{Binding EditKeyCommand}"
-                                IsVisible="{Binding !KeyIsInEditMode}">
-                            <StackPanel>
-                                <Label Classes="icon" Content="&#xe3B4;"></Label>
-                            </StackPanel>
-                        </Button>
-                        <Button Classes="decorator"
-                                Command="{Binding SaveKeyCommand}"
-                                IsVisible="{Binding KeyIsInEditMode}">
-                            <StackPanel>
-                                <Label Classes="icon" Content="&#xe182;"></Label>
-                            </StackPanel>
-                        </Button>
-                        <Button Classes="decorator"
-                                Command="{Binding CancelSaveKeyCommand}"
-                                IsVisible="{Binding KeyIsInEditMode}"
-                                BorderBrush="{DynamicResource PrimaryForeground}"
-                                BorderThickness="0 1 1 1">
-                            <StackPanel>
-                                <Label Classes="icon" Content="&#xe038;"></Label>
-                            </StackPanel>
-                        </Button>
-                    </StackPanel>
-                </Grid>
-                <Button Content="{x:Static lang:Resources.BtnSaveSettingsText}"
-                        Command="{Binding SaveSettingsCommand}"
-                        CommandParameter="{Binding}"
-                        Classes="command" />
+            <!-- Use Trailing Stop -->
+            <StackPanel Classes="formField" Grid.Row="2" Grid.Column="2" Orientation="Horizontal"
+                        VerticalAlignment="Bottom">
+                <CheckBox Content="{x:Static lang:Resources.Use}"
+                          IsChecked="{Binding SettingsDefaultUseTrailingStop}" />
             </StackPanel>
 
+            <StackPanel Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"></StackPanel>
         </Grid>
 
+        <StackPanel Grid.Row="2" Classes="formField" HorizontalAlignment="Stretch">
+            <StackPanel.Styles>
+                <Style Selector="TextBox">
+                    <Setter Property="BorderBrush" Value="{DynamicResource PrimaryForeground}"></Setter>
+                    <Setter Property="BorderThickness" Value="1 1 0 1"></Setter>
+                    <Setter Property="HorizontalAlignment" Value="Stretch"></Setter>
+                </Style>
+            </StackPanel.Styles>
+            <Label Content="{x:Static lang:Resources.KeyLabel}"></Label>
+            <StackPanel Classes="formField" Orientation="Horizontal">
+                <TextBox Name="TokenInput" Text="{Binding Key}"
+                         IsEnabled="{Binding  KeyIsInEditMode}"
+                         HorizontalAlignment="Stretch" />
+                <!--Edit-->
+                <Button Classes="decorator"
+                        Command="{Binding EditKeyCommand}"
+                        IsVisible="{Binding !KeyIsInEditMode}">
+                    <StackPanel>
+                        <!--pencil-->
+                        <Label Classes="icon" Content="&#xe3B4;"></Label>
+                    </StackPanel>
+                </Button>
+
+                <!--Save changes-->
+                <Button Classes="decorator"
+                        Command="{Binding SaveKeyCommand}"
+                        IsVisible="{Binding KeyIsInEditMode}">
+                    <StackPanel>
+                        <!--check mark-->
+                        <Label Classes="icon" Content="&#xe182;"></Label>
+                    </StackPanel>
+                </Button>
+
+                <!--Discard changes-->
+                <Button Classes="decorator"
+                        Command="{Binding CancelSaveKeyCommand}"
+                        IsVisible="{Binding KeyIsInEditMode}"
+                        BorderBrush="{DynamicResource PrimaryForeground}"
+                        BorderThickness="0 1 1 1">
+                    <StackPanel>
+                        <!--circle with ccw arrow-->
+                        <!--<Label Classes="icon" Content="&#xe038;"></Label>-->
+                        <Label Classes="icon" Content="&#xe4F6;"></Label>
+                    </StackPanel>
+                </Button>
+            </StackPanel>
+            <Button Content="{x:Static lang:Resources.BtnSaveSettingsText}"
+                    Command="{Binding SaveSettingsCommand}"
+                    CommandParameter="{Binding}"
+                    HorizontalAlignment="Stretch"
+                    Classes="command" />
+        </StackPanel>
     </Grid>
 
 </UserControl>

--- a/Signals/Signals/Views/WatchlistItemPageView.axaml
+++ b/Signals/Signals/Views/WatchlistItemPageView.axaml
@@ -71,8 +71,10 @@
                             </Grid>
                         </StackPanel>
                         <StackPanel Grid.Row="1"  Orientation="Horizontal">
-                            <IconButton IconText="&#xE4A6;" Content="Delete"></IconButton>
-                            <IconButton IconText="&#xEB48;" Content="Buy"></IconButton>
+                            <IconButton Classes="command" IconText="&#xE4A6;" Content="Delete"
+                                        Command="{Binding $parent[UserControl].((vm:WatchlistItemPageViewModel)DataContext).DeleteWatchlistItemCommand, FallbackValue=null}"
+                                        ></IconButton>
+                            <IconButton Classes="buy" IconText="&#xEB48;" Content="Buy"></IconButton>
                         </StackPanel>
                     </Grid>
                 </DataTemplate>


### PR DESCRIPTION
Due to a bug in the dynamic referencing feature of Avalonia, acted on Angel6's advice and copied the original checkbox definition from the Avalonia repo and modified to get all the styles to my liking fore each checkbox state.