### PR TITLE
Workaround for NumericUpDown control that was producing erroneous output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # Signals
-Track your favourite capital market securities an watch for significant patterns and events.
+
+Track your favourite capital market securities and watch for significant patterns and events.
+

--- a/Signals/Signals/Converters/CurrencyOrEmptyConverter.cs
+++ b/Signals/Signals/Converters/CurrencyOrEmptyConverter.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Globalization;
+using Avalonia.Data;
+using Avalonia.Data.Converters;
+
+namespace Signals.Converters;
+
+// Empty string <-> null; valid digits <-> int
+public sealed class CurrencyOrEmptyConverter : IValueConverter
+{
+    public static readonly CurrencyOrEmptyConverter Instance = new();
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is decimal i)
+            return i.ToString("C", culture);
+
+        // When source is null (decimal?), show empty
+        return string.Empty;
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        var s = value as string;
+
+        if (string.IsNullOrWhiteSpace(s))
+            return null; // empty -> null (safe for decimal?)
+
+        if (decimal.TryParse(s, NumberStyles.Currency | NumberStyles.AllowDecimalPoint, culture, out var i))
+            return i;
+
+        // Keep the previous source value if parse fails
+        return BindingOperations.DoNothing;
+    }
+}

--- a/Signals/Signals/Converters/DecimalOrEmptyConverter.cs
+++ b/Signals/Signals/Converters/DecimalOrEmptyConverter.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Globalization;
+using Avalonia.Data;
+using Avalonia.Data.Converters;
+
+namespace Signals.Converters;
+
+// Empty string <-> null; valid digits <-> int
+public sealed class DecimalOrEmptyConverter : IValueConverter
+{
+    public static readonly DecimalOrEmptyConverter Instance = new();
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is decimal i)
+            return i.ToString(culture);
+
+        // When source is null (decimal?), show empty
+        return string.Empty;
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        var s = value as string;
+
+        if (string.IsNullOrWhiteSpace(s))
+            return null; // empty -> null (safe for decimal?)
+
+        if (decimal.TryParse(s, NumberStyles.AllowDecimalPoint, culture, out var i))
+            return i;
+
+        // Keep the previous source value if parse fails
+        return BindingOperations.DoNothing;
+    }
+}

--- a/Signals/Signals/Converters/IntOrEmptyConverter.cs
+++ b/Signals/Signals/Converters/IntOrEmptyConverter.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Globalization;
+using Avalonia.Data;
+using Avalonia.Data.Converters;
+
+namespace Signals.Converters;
+
+// Empty string <-> null; valid digits <-> int
+public sealed class IntOrEmptyConverter : IValueConverter
+{
+    public static readonly IntOrEmptyConverter Instance = new();
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is int i)
+            return i.ToString(culture);
+
+        // When source is null (int?), show empty
+        return string.Empty;
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        var s = value as string;
+
+        if (string.IsNullOrWhiteSpace(s))
+            return null; // empty -> null (safe for int?)
+
+        if (int.TryParse(s, NumberStyles.Integer, culture, out var i))
+            return i;
+
+        // Keep the previous source value if parse fails
+        return BindingOperations.DoNothing;
+    }
+}

--- a/Signals/Signals/Converters/IntOrZeroConverter.cs
+++ b/Signals/Signals/Converters/IntOrZeroConverter.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Globalization;
+using Avalonia.Data;
+using Avalonia.Data.Converters;
+
+namespace Signals.Converters;
+
+// Empty string -> 0; valid digits -> int
+public sealed class IntOrZeroConverter : IValueConverter
+{
+    public static readonly IntOrZeroConverter Instance = new();
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is int i)
+            return i.ToString(culture);
+
+        return "0";
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        var s = value as string;
+
+        if (string.IsNullOrWhiteSpace(s))
+            return 0; // empty -> 0
+
+        if (int.TryParse(s, NumberStyles.Integer, culture, out var i))
+            return i;
+
+        return BindingOperations.DoNothing;
+    }
+}

--- a/Signals/Signals/Converters/UpperCaseConverter.cs
+++ b/Signals/Signals/Converters/UpperCaseConverter.cs
@@ -13,6 +13,6 @@ public class UpperCaseConverter : IValueConverter
 
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        return value?.ToString()?.ToUpper();
+        return value?.ToString()?.ToLower();
     }
 }

--- a/Signals/Signals/CoreLayer/Entities/Holding.cs
+++ b/Signals/Signals/CoreLayer/Entities/Holding.cs
@@ -21,9 +21,9 @@ public class Holding : StockItem
         WhenLastPurchased = DateTime.UtcNow;
     }
 
-    public decimal QuantityHeld { get; set; }
+    public int QuantityHeld { get; set; }
     public DateTime WhenLastPurchased { get; set; }
-    public decimal PeakPriceSincePurchase { get; set; }
+    public decimal? PeakPriceSincePurchase { get; set; }
     public decimal? HighTargetPrice { get; set; }
     public decimal? LowTargetPrice { get; set; }
     public decimal AveragePurchasePrice { get; set; }

--- a/Signals/Signals/Resources/AppResources.axaml
+++ b/Signals/Signals/Resources/AppResources.axaml
@@ -46,7 +46,7 @@
     <CornerRadius x:Key="CheckBoxCornerRadius">30</CornerRadius>
     <CornerRadius x:Key="TextBoxCornerRadius">3</CornerRadius>
     
-    <Color x:Key="MainSectionBackground">AntiqueWhite</Color>
+    <Color x:Key="MainSectionBackground">Gray</Color>
     <Color x:Key="WindowBackground">SteelBlue</Color>
     <Color x:Key="WindowBackground1">#FFA9BCCF</Color>
     <Color x:Key="PrimaryPageForeground">Black</Color>

--- a/Signals/Signals/Styles/AppDefaultStyles.axaml
+++ b/Signals/Signals/Styles/AppDefaultStyles.axaml
@@ -2,7 +2,6 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Design.PreviewWith>
         <Border Padding="20" Width="400">
-            <!-- Background="{DynamicResource MainSectionBackground} -->
             <Border Classes="main-section" >
                 <Grid ColumnDefinitions="*, *">
                     <!-- Add Controls for Previewer Here -->

--- a/Signals/Signals/ViewModels/BuyOrSellDialogViewModel.cs
+++ b/Signals/Signals/ViewModels/BuyOrSellDialogViewModel.cs
@@ -11,8 +11,8 @@ public partial class BuyOrSellDialogViewModel : DialogViewModel
     [ObservableProperty] [NotifyPropertyChangedFor(nameof(SaveIsEnabled))] private string _symbol = String.Empty;
     [ObservableProperty] private string _title = String.Empty;
     [ObservableProperty] private DateTime _transactionTime = DateTime.UtcNow;
-    [ObservableProperty] [NotifyPropertyChangedFor(nameof(SaveIsEnabled))] private int _units;
-    [ObservableProperty] [NotifyPropertyChangedFor(nameof(SaveIsEnabled))] private decimal _price;
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(SaveIsEnabled))] private int? _units;
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(SaveIsEnabled))] private decimal? _price;
 
     [ObservableProperty] private string _confirmText = "Confirm";
     [ObservableProperty] private string _cancelText = "Cancel";
@@ -50,8 +50,11 @@ public partial class BuyOrSellDialogViewModel : DialogViewModel
     
     #region Computed and non data members
     
+    // Bug: The value converter for the units is necessary to avoid an invalid cast exception and an error message
+    // in the NumericUpDown if its text box is cleared, but it interferes with the notification system, and there's
+    // no way to fix it from my code.
     public bool SaveIsEnabled
-        => !string.IsNullOrEmpty(Symbol) && Units > 0 && Price > 0;
+        => !string.IsNullOrEmpty(Symbol) && Units is > 0 && Price is > 0;
 
     public TransactionTypes Action { get; set; }
 

--- a/Signals/Signals/ViewModels/HoldingsItemPageViewModel.cs
+++ b/Signals/Signals/ViewModels/HoldingsItemPageViewModel.cs
@@ -82,8 +82,8 @@ public partial class HoldingsItemPageViewModel : PageViewModel
         
         if (buyOrSellViewDialogModel.IsConfirmed == false) return;
         
-        holding.QuantityHeld = buyOrSellViewDialogModel.Units;
-        holding.AveragePurchasePrice = buyOrSellViewDialogModel.Price;
+        holding.QuantityHeld = buyOrSellViewDialogModel.Units.Value;
+        holding.AveragePurchasePrice = buyOrSellViewDialogModel.Price.Value;
 
         await HoldingService.Buy(holding);
 
@@ -107,8 +107,8 @@ public partial class HoldingsItemPageViewModel : PageViewModel
         
         if (buyOrSellViewDialogModel.IsConfirmed == false) return;
 
-        holding.QuantityHeld = buyOrSellViewDialogModel.Units;
-        holding.AveragePurchasePrice = buyOrSellViewDialogModel.Price;
+        holding.QuantityHeld = buyOrSellViewDialogModel.Units.Value;
+        holding.AveragePurchasePrice = buyOrSellViewDialogModel.Price.Value;
         
         await HoldingService.Sell(holding);
         

--- a/Signals/Signals/ViewModels/WatchlistItemPageViewModel.cs
+++ b/Signals/Signals/ViewModels/WatchlistItemPageViewModel.cs
@@ -107,8 +107,8 @@ public partial class WatchlistItemPageViewModel : PageViewModel
         
         var holding = Mapper.Map<Holding>(watchlistItem);
         holding.Symbol = buyOrSellDialog.Symbol;
-        holding.QuantityHeld = buyOrSellDialog.Units;
-        holding.AveragePurchasePrice = buyOrSellDialog.Price;
+        holding.QuantityHeld = buyOrSellDialog.Units.Value;
+        holding.AveragePurchasePrice = buyOrSellDialog.Price ?? 0;
         await HoldingService.Buy(holding);
         
         MainViewModel.GoToHoldingDetailCommand.Execute(holding.Symbol);

--- a/Signals/Signals/Views/BuyOrSellDialogView.axaml
+++ b/Signals/Signals/Views/BuyOrSellDialogView.axaml
@@ -5,12 +5,20 @@
              mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="450"
              xmlns:viewModels="clr-namespace:Signals.ViewModels"
              xmlns:lang="clr-namespace:Signals.Resources"
+             xmlns:converters="clr-namespace:Signals.Converters"
              x:Class="Signals.Views.BuyOrSellDialogView"
              x:DataType="viewModels:BuyOrSellDialogViewModel">
 
     <Design.DataContext>
         <viewModels:BuyOrSellDialogViewModel></viewModels:BuyOrSellDialogViewModel>
     </Design.DataContext>
+
+    <UserControl.Resources>
+        <converters:IntOrEmptyConverter x:Key="IntOrEmptyConverter" />
+        <converters:IntOrZeroConverter x:Key="IntOrZeroConverter" />
+        <converters:CurrencyOrEmptyConverter x:Key="CurrencyOrEmptyConverter" />
+        <converters:DecimalOrEmptyConverter x:Key="DecimalOrEmptyConverter" />
+    </UserControl.Resources>
 
     <Border Background="{DynamicResource PrimaryDialogBackground}"
             CornerRadius="10"
@@ -33,7 +41,6 @@
                            Foreground="{DynamicResource TitleBarForeground}" />
             </Border>
 
-            
             <Border Grid.Row="1" Padding="20">
                 <StackPanel>
                     <Label Content="{x:Static lang:Resources.SymbolLabel}"></Label>
@@ -41,13 +48,20 @@
                     <Label Content="{x:Static lang:Resources.DateLabel}"></Label>
                     <TextBox Text="{Binding TransactionTime}"></TextBox>
                     <Label Content="{x:Static lang:Resources.UnitsLabel}"></Label>
-                    <NumericUpDown Value="{Binding Units}"  
+                    <!--Bug - can't use a value converter because the Numeric UpDown won't bind if you do.-->
+                    <!--The value converter prevents an invalid cast exception if the TextBox part of the UpDown is 
+                    empty.  I can't find a way to fix this in my application, so we're just going to have to put up
+                    with this annoying little glitch for now.  -->
+                    <NumericUpDown Value="{Binding Units, UpdateSourceTrigger=LostFocus, 
+                                   TargetNullValue=0, FallbackValue=0}"  
                                    FormatString="###,###,##0"
                                    Minimum="0" Maximum="10000000"
                                    />
                     <!--<TextBox Text="{Binding Units}" />-->
                     <Label Content="{x:Static lang:Resources.PriceLabel}"></Label>
-                    <TextBox Text="{Binding Price}"></TextBox>
+                    <TextBox Text="{Binding Price,
+                             Converter={StaticResource CurrencyOrEmptyConverter}}"
+                             />
                 </StackPanel>
             </Border>
 

--- a/Signals/Signals/Views/HoldingsItemPageView.axaml
+++ b/Signals/Signals/Views/HoldingsItemPageView.axaml
@@ -7,11 +7,16 @@
              xmlns:vm="clr-namespace:Signals.ViewModels"
              xmlns:entities="clr-namespace:Signals.CoreLayer.Entities"
              x:Class="Signals.Views.HoldingsItemPageView"
-             x:DataType="vm:HoldingsItemPageViewModel">
-
+             x:DataType="vm:HoldingsItemPageViewModel"
+             xmlns:converters="clr-namespace:Signals.Converters">
+    <!-- added xmlns:converters -->
     <Design.DataContext>
         <vm:HoldingsItemPageViewModel />
     </Design.DataContext>
+    <UserControl.Resources>
+        <converters:CurrencyOrEmptyConverter x:Key="DecimalOrEmptyConverter" />
+    </UserControl.Resources>
+    
 
     <Grid>
         <ContentControl Content="{Binding HoldingItem}">
@@ -91,8 +96,7 @@
                                     <StackPanel Grid.Row="3" Grid.Column="2">
                                         <Label Content="Number of Units Held" />
                                         <TextBox
-                                            Text="{Binding  QuantityHeld, StringFormat={}{0:#0}, 
-                                        FallbackValue=0, TargetNullValue=0}" />
+                                            Text="{Binding  QuantityHeld, StringFormat={}{0:#0}}" />
                                     </StackPanel>
 
                                     <StackPanel Grid.Row="4" Grid.Column="0">
@@ -102,27 +106,22 @@
 
                                     <StackPanel Grid.Row="4" Grid.Column="2">
                                         <Label Content="Peak Price Since Purchase" />
-                                        <TextBox Text="{Binding  PeakPriceSincePurchase, StringFormat={}{0:C}}" />
+                                        <TextBox Text="{Binding  PeakPriceSincePurchase, 
+                                                 Converter={x:Static converters:CurrencyOrEmptyConverter.Instance}, 
+                                                 UpdateSourceTrigger=PropertyChanged, StringFormat={}{0:C}}" />
                                     </StackPanel>
 
-                                    <!--<StackPanel Grid.Row="5" Grid.Column="0">
-                                        <Label Content="Gain/Loss" />
-                                        <TextBox Text="{Binding  GainOrLoss, StringFormat={}{0:C}}" />
-                                    </StackPanel>-->
-
-                                    <!--<StackPanel Grid.Row="5" Grid.Column="2">
-                                        <Label Content="Peak Price Since Purchase" />
-                                        <TextBox Text="{Binding  PeakPriceSincePurchase, StringFormat={}{0:C}}" />
-                                    </StackPanel>-->
-
+                                    <!-- ... existing code ... -->
                                     <StackPanel Grid.Row="6" Grid.Column="0">
                                         <Label Content="High Target Price" />
-                                        <TextBox Text="{Binding  HighTargetPrice, StringFormat={}{0:C}}" />
+                                        <TextBox
+                                            Text="{Binding HighTargetPrice, Converter={StaticResource DecimalOrEmptyConverter}, UpdateSourceTrigger=PropertyChanged}" />
                                     </StackPanel>
 
                                     <StackPanel Grid.Row="6" Grid.Column="2">
                                         <Label Content="Low Target Price" />
-                                        <TextBox Text="{Binding  LowTargetPrice, StringFormat={}{0:C}}" />
+                                        <TextBox
+                                            Text="{Binding LowTargetPrice, Converter={StaticResource DecimalOrEmptyConverter}, UpdateSourceTrigger=PropertyChanged}" />
                                     </StackPanel>
                                 </Grid>
                                 <StackPanel>


### PR DESCRIPTION
An issue peculiar to the NumericUpDown control caused undesirable error output to appear in the UI.  Value converters would resolve the issue, but would also interfere with the binding pipeline.