### PR TITLE
Add local time converter

### DIFF
--- a/Signals/Signals.Android/Scheduling/Scheduler.cs
+++ b/Signals/Signals.Android/Scheduling/Scheduler.cs
@@ -13,13 +13,19 @@ public static class Scheduler
 
     internal static void ConfigureWorkManager()
     {
+        // We're probably going to need an exablement screen in order to launch the periodic work request, so
+        // that we can configure the network type and other settings.  If we want to change the network type, later
+        // on, we'll need to cancel the work request and re-create it.'
+        
         try
         {
+            // var fileService = new FileService();
             // var appConfigService = new SignalsConfigurationService(fileService);
             // var appConfig = appConfigService.GetConfig();
+            // var requiredNetworkType = appConfig.UsePhoneData ? NetworkType.Connected! : NetworkType.Unmetered!;
 
-            //var requiredNetworkType = appConfig.UsePhoneData ? NetworkType.Connected! : NetworkType.Unmetered!;
-            var requiredNetworkType = NetworkType.NotRequired!;
+            // May need to ask for user operation to use cellular data.  For testing, assume Wifi is available.
+            var requiredNetworkType = NetworkType.Unmetered!;
 
             var constraints = new Constraints.Builder()
                 .SetRequiredNetworkType(requiredNetworkType)
@@ -37,21 +43,42 @@ public static class Scheduler
             // Configure the repeat interval for 24 hours.  Set the flex interval to the last 12 hours.
             // This will ensure that the worker has time to run during the evening, after the stock
             // markets have closed.
-            // var repeatInterval = TimeSpan.FromHours(24);  // Cycle interval.
-            // var flexInterval = TimeSpan.FromHours(12);    // Time within the cycle to run (last 12 hours).
+            var repeatInterval = TimeSpan.FromHours(24);  // Cycle interval.
+            var flexInterval = TimeSpan.FromMinutes(15);  // Time within the cycle to run (last 12 hours).
 
-            // Time delay before starting the first iteration.
-            // var initialDelay = TimeSpan.Zero;
+             // Time delay before starting the first iteration.
+            // var initialDelay = TimeSpan.FromMinutes(5);
             // var minutesTillMidnight = (24 - DateTime.UtcNow.Hour) * 60;
 
+            // Get Eastern Time Zone (handles EST/EDT)
+            var easternTimeZone = TimeZoneInfo.FindSystemTimeZoneById(
+                OperatingSystem.IsWindows() ? "Eastern Standard Time" : "America/New_York");
+
+            // Calculate initial delay to next 4:30 PM EST/EDT
+            var now = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, easternTimeZone);
+            var targetTime = new DateTime(now.Year, now.Month, now.Day, 16, 30, 0); // 4:30 PM
+            if (now >= targetTime)
+            {
+                targetTime = targetTime.AddDays(1); // Next day
+            }
+            var initialDelay = (targetTime - now).Minutes;
+            
             // Create the work request to periodically run the worker that updates all stock quotes
+            // PeriodicWorkRequest quotationSchedule = (PeriodicWorkRequest)PeriodicWorkRequest.Builder
+            //     .From<QuoteWorker>(repeatInterval, flexInterval)
+            //     .SetBackoffCriteria(BackoffPolicy.Exponential!, backOffDelay.Minutes, TimeUnit.Minutes!)
+            //     .SetInitialDelay(initialDelay, TimeUnit.Minutes!)!
+            //     .SetConstraints(constraints)
+            //     .AddTag(PlatformTag)
+            //     .Build();
             PeriodicWorkRequest quotationSchedule = (PeriodicWorkRequest)PeriodicWorkRequest.Builder
-                .From<QuoteWorker>(TimeSpan.FromMinutes(15), TimeSpan.FromMinutes(5))
+                .From<QuoteWorker>(TimeSpan.FromMinutes(60), TimeSpan.FromMinutes(15))
                 .SetBackoffCriteria(BackoffPolicy.Exponential!, backOffDelay.Minutes, TimeUnit.Minutes!)
                 .SetInitialDelay(5, TimeUnit.Minutes!)!
                 .SetConstraints(constraints)
                 .AddTag(PlatformTag)
                 .Build();
+
 
             // var op = WorkManager.GetInstance(App.Context).Enqueue(sigalsQuotationScheduler);
             var mgr = WorkManager.GetInstance(Xamarin.Essentials.Platform.AppContext);
@@ -65,16 +92,40 @@ public static class Scheduler
         }
     }
 }
+
+
+
+
+
 //#if RELEASE
 // Create the work request to periodically run the worker that updates all stock quotes
 /*
-PeriodicWorkRequest quotationSchedule = (PeriodicWorkRequest)PeriodicWorkRequest.Builder
-    .From<QuoteWorker>(TimeSpan.FromMinutes(15), TimeSpan.FromMinutes(5))
-    .SetBackoffCriteria(BackoffPolicy.Exponential!, backOffDelay.Minutes, TimeUnit.Minutes!)
-    .SetInitialDelay(5, TimeUnit.Minutes!)!
-    .SetConstraints(constraints)
-    .AddTag(PlatformTag)
-    .Build();
+            THE FINAL VERSION OF THE WORKER:
+            // PeriodicWorkRequest quotationSchedule = (PeriodicWorkRequest)PeriodicWorkRequest.Builder
+            //     .From<QuoteWorker>(repeatInterval, flexInterval)
+            //     .SetBackoffCriteria(BackoffPolicy.Exponential!, backOffDelay.Minutes, TimeUnit.Minutes!)
+            //     .SetInitialDelay(initialDelay, TimeUnit.Minutes!)!
+            //     .SetConstraints(constraints)
+            //     .AddTag(PlatformTag)
+            //     .Build();
+            
+            TEST VERSION 1:
+                PeriodicWorkRequest quotationSchedule = (PeriodicWorkRequest)PeriodicWorkRequest.Builder
+                .From<QuoteWorker>(TimeSpan.FromMinutes(15), TimeSpan.FromMinutes(5))
+                .SetBackoffCriteria(BackoffPolicy.Exponential!, backOffDelay.Minutes, TimeUnit.Minutes!)
+                .SetInitialDelay(5, TimeUnit.Minutes!)!
+                .SetConstraints(constraints)
+                .AddTag(PlatformTag)
+                .Build();
+
+            TEST VERSION 2:
+            PeriodicWorkRequest quotationSchedule = (PeriodicWorkRequest)PeriodicWorkRequest.Builder
+                .From<QuoteWorker>(repeatInterval, flexInterval)
+                .SetBackoffCriteria(BackoffPolicy.Exponential!, backOffDelay.Minutes, TimeUnit.Minutes!)
+                .SetInitialDelay(minutesTillMidnight, TimeUnit.Minutes!)!
+                .SetConstraints(constraints)
+                .AddTag(PlatformTag)
+                .Build();
 
 // var op = WorkManager.GetInstance(App.Context).Enqueue(sigalsQuotationScheduler);
 var mgr = WorkManager.GetInstance(Xamarin.Essentials.Platform.AppContext);

--- a/Signals/Signals/ApplicationLayer/Services/PriceRefreshService.cs
+++ b/Signals/Signals/ApplicationLayer/Services/PriceRefreshService.cs
@@ -96,6 +96,10 @@ public class PriceRefreshService : IPriceRefreshService
                 var quote = await QuotationService.GetQuoteAsync(index.Symbol);
                 index.LatestQuotedPrice = quote?.LatestQuotedPrice ?? 0;
                 index.WhenLatestQuoteReceived = quote?.WhenLatestQuoteReceived;
+                index.CurrentDayOpeningPrice = quote?.CurrentDayOpeningPrice ?? 0;
+                index.CurrentDayHighPrice = quote?.CurrentDayHighPrice ?? 0;
+                index.CurrentDayLowPrice = quote?.CurrentDayLowPrice ?? 0;
+                index.PreviousDayClosingPrice = quote?.PreviousDayClosingPrice ?? 0;
                 await IndexService.Update(index);
 
                 // index.LatestQuotedPrice = 100 + itemsUpdated * 10;

--- a/Signals/Signals/Converters/LocalTimeConverter.cs
+++ b/Signals/Signals/Converters/LocalTimeConverter.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Globalization;
+using Avalonia.Data.Converters;
+
+namespace Signals.Converters;
+
+public class LocalTimeConverter : IValueConverter
+{
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        var result = ((DateTime)(value ?? DateTime.Today)).ToLocalTime();
+        return result;
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        var result = ((DateTime)(value ?? DateTime.Today)).ToUniversalTime();
+        return result;
+    }
+}

--- a/Signals/Signals/Views/HoldingsItemPageView.axaml
+++ b/Signals/Signals/Views/HoldingsItemPageView.axaml
@@ -16,6 +16,7 @@
     </Design.DataContext>
     <UserControl.Resources>
         <converters:CurrencyOrEmptyConverter x:Key="DecimalOrEmptyConverter" />
+        <converters:LocalTimeConverter x:Key="LocalTimeConverter" />
     </UserControl.Resources>
     
 
@@ -42,8 +43,9 @@
                                 <Label Content="Exchange" />
                                 <TextBlock Text="{Binding  ExchangeName}" />
                                 <Label Content="Quote Received" />
-                                <TextBlock
-                                    Text="{Binding  WhenLatestQuoteReceived, StringFormat={}{0:MMM d\, yyyy hh:mm tt}}" />
+                                <TextBlock Text="{Binding  WhenLatestQuoteReceived, 
+                                    StringFormat={}{0:MMM d\, yyyy hh:mm tt}
+                                    , Converter={StaticResource LocalTimeConverter}}" />
 
                                 <Grid RowDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto"
                                       ColumnDefinitions="*,5,*">


### PR DESCRIPTION
All dates are stored in Coordinated Universal Time (UCT).   Adding a converter to convert to local time for display purposes, and editing, and then back to Universal Time for saving back to the database.