### PR TITLE
Apply local time converter, rearrange some pages

### DIFF
--- a/Signals/Signals/Controls/StockItemHeader.axaml
+++ b/Signals/Signals/Controls/StockItemHeader.axaml
@@ -33,7 +33,8 @@
                             <StackPanel Grid.Row="1" Grid.Column="1">
                                 <TextBlock
                                     Text="{Binding WhenLatestQuoteReceived, 
-                                        RelativeSource={RelativeSource TemplatedParent}, StringFormat={}{0:MMM d\, yyyy hh:mm tt}}" />
+                                        RelativeSource={RelativeSource TemplatedParent}, StringFormat={}{0:MMM d\, yyyy hh:mm tt}
+                                        }" />
                             </StackPanel>
                             <StackPanel Grid.Row="1" Grid.Column="2">
                                 <TextBlock

--- a/Signals/Signals/ViewModels/SettingsPageViewModel.cs
+++ b/Signals/Signals/ViewModels/SettingsPageViewModel.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using AutoMapper;
+using Avalonia.Controls;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Signals.ApplicationLayer.Abstract;
@@ -88,7 +89,16 @@ public partial class SettingsPageViewModel : PageViewModel
     {
         KeyIsInEditMode = true;
     }
-
+    [RelayCommand]
+    public async Task GetKey(Button getKeyButton)
+    {
+        // Get key from Quotation Service and apply to the application configuration.
+        var uri = new Uri("https://finnhub.io/");
+        var launcher = TopLevel.GetTopLevel(getKeyButton)?.Launcher;
+        if (launcher == null) return;
+        var success = await launcher.LaunchUriAsync(uri);
+    }
+    
     [RelayCommand]
     private void SaveConfig()
     {

--- a/Signals/Signals/Views/AboutPageView.axaml
+++ b/Signals/Signals/Views/AboutPageView.axaml
@@ -32,7 +32,6 @@
                 <Button Name="BtnGetKey" Content="{x:Static lang:Resources.BtnGetKeyContent}"
                         Command="{Binding GetKeyCommand}"
                         CommandParameter="{Binding $self}" />
-                <!-- Click="BtnGetKey_OnClick" -->
                 <TextBlock Name="VersionStatement" Text="{x:Static lang:Resources.ApplicationVersionStatement}" />
                 <TextBlock Name="VersionStatement2" Text="Version 1.0 released 2025" />
                 <Button Name="BtnCheckForNewVersion" Content="{x:Static lang:Resources.BtnCheckForNewVersionContent}"

--- a/Signals/Signals/Views/HoldingsItemPageView.axaml
+++ b/Signals/Signals/Views/HoldingsItemPageView.axaml
@@ -2,7 +2,6 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:controls="clr-namespace:Signals.Controls"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              xmlns:vm="clr-namespace:Signals.ViewModels"
 			 xmlns:local="clr-namespace:Signals.Views"
@@ -94,7 +93,9 @@
                                     <StackPanel Grid.Row="3" Grid.Column="0">
                                         <Label Content="When Purchased" />
                                         <TextBlock
-                                            Text="{Binding  WhenLastPurchased, StringFormat={}{0:MMM d\, yyyy hh:mm tt}}" />
+                                            Text="{Binding  WhenLastPurchased, 
+                                            StringFormat={}{0:MMM d\, yyyy hh:mm tt}
+                                            , Converter={StaticResource LocalTimeConverter}}" />
                                     </StackPanel>
 
                                     <StackPanel Grid.Row="3" Grid.Column="2">

--- a/Signals/Signals/Views/HomePageView.axaml
+++ b/Signals/Signals/Views/HomePageView.axaml
@@ -5,12 +5,16 @@
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              xmlns:controls="clr-namespace:Signals.Controls"
              xmlns:vm="clr-namespace:Signals.ViewModels"
-             xmlns:entities="clr-namespace:Signals.CoreLayer.Entities"
              x:DataType="vm:HomePageViewModel"
-             x:Class="Signals.Views.HomePageView">
+             x:Class="Signals.Views.HomePageView"
+             xmlns:converters="clr-namespace:Signals.Converters">
+
     <Design.DataContext>
         <vm:HomePageViewModel />
     </Design.DataContext>
+    <UserControl.Resources>
+        <converters:LocalTimeConverter x:Key="LocalTimeConverter" />
+    </UserControl.Resources>
 
     <Grid RowDefinitions="Auto, 10, *">
 
@@ -29,7 +33,8 @@
                                     Name="{Binding Name}"
                                     ColourByTrend="{Binding ColourByTrend}"
                                     LatestQuotedPrice="{Binding LatestQuotedPrice}"
-                                    WhenLatestQuoteReceived="{Binding WhenLatestQuoteReceived}"
+                                    WhenLatestQuoteReceived="{Binding WhenLatestQuoteReceived
+                                    , Converter={StaticResource LocalTimeConverter}}"
                                     CurrentDayPercentChange="{Binding CurrentDayPercentChange}" />
                             </StackPanel>
                         </DataTemplate>

--- a/Signals/Signals/Views/SettingsPageView.axaml
+++ b/Signals/Signals/Views/SettingsPageView.axaml
@@ -11,13 +11,61 @@
     <Design.DataContext>
         <vm:SettingsPageViewModel />
     </Design.DataContext>
+
     <Grid RowDefinitions="Auto, *, Auto">
-        <Label Grid.Row="0" Classes="heading" Content="{Binding PageSubtitle}"></Label>
+        <StackPanel Grid.Row="0">
+            <TextBlock  HorizontalAlignment="Center" Classes="page-title" Text="Configure settings and preferences"></TextBlock>
+        </StackPanel>
 
         <Grid Grid.Row="1" RowDefinitions="Auto, Auto, Auto, *, Auto" ColumnDefinitions="Auto, 16, *">
 
-            <Label Content="{x:Static lang:Resources.SettingsMetadataVersionLabel}"></Label>
-            <TextBlock Grid.Row="0" Grid.Column="2" Text="{Binding MetadataVersion}"></TextBlock>
+            <StackPanel Grid.Row="0" Grid.ColumnSpan="3" Spacing="5">
+                <Label Content="{x:Static lang:Resources.KeyLabel}"></Label>
+                <!-- Grid containing the controls for setting the API key for the quotation service-->
+                <Grid ColumnDefinitions="*, Auto">
+                    <TextBox Name="TokenInput" Text="{Binding Key}"
+                             IsEnabled="{Binding  KeyIsInEditMode}"
+                             HorizontalAlignment="Stretch" />
+                    <!-- Edit the key -->
+                    <Button Grid.Column="1" Classes="decorator"
+                            Command="{Binding EditKeyCommand}"
+                            IsVisible="{Binding !KeyIsInEditMode}">
+                        <StackPanel>
+                            <!--pencil-->
+                            <Label Classes="icon" Content="&#xe3B4;"></Label>
+                        </StackPanel>
+                    </Button>
+
+                    <!-- Save an updated key value -->
+                    <StackPanel Grid.Column="1" Orientation="Horizontal">
+                        <Button Classes="decorator"
+                                Command="{Binding SaveConfigCommand}"
+                                IsVisible="{Binding KeyIsInEditMode}">
+                            <StackPanel>
+                                <!--check mark icon-->
+                                <Label Classes="icon" Content="&#xe182;"></Label>
+                            </StackPanel>
+                        </Button>
+
+                        <!-- Discard changes, restoring previous value -->
+                        <Button Classes="decorator"
+                                Command="{Binding CancelSaveKeyCommand}"
+                                IsVisible="{Binding KeyIsInEditMode}"
+                                BorderBrush="{DynamicResource PrimaryForeground}"
+                                BorderThickness="0 1 1 1">
+                            <StackPanel>
+                                <!-- Label with X icon -->
+                                <Label Classes="icon" Content="&#xe038;"></Label>
+                            </StackPanel>
+                        </Button>
+                    </StackPanel>
+                </Grid>
+
+                <!-- Contact the service provider to get an API key -->
+                <Button Name="BtnGetKey" Content="{x:Static lang:Resources.BtnGetKeyContent}"
+                        Command="{Binding GetKeyCommand}"
+                        CommandParameter="{Binding $self}" />
+            </StackPanel>
 
             <!-- Default Gain Alert Level -->
             <StackPanel Classes="formField" Grid.Row="1" Grid.Column="0" HorizontalAlignment="Stretch">
@@ -48,7 +96,10 @@
                           IsChecked="{Binding DefaultUseTrailingStop}" />
             </StackPanel>
 
-            <StackPanel Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"></StackPanel>
+            <StackPanel Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2">
+                <Label Content="{x:Static lang:Resources.SettingsMetadataVersionLabel}"></Label>
+                <TextBlock Grid.Row="0" Grid.Column="2" Text="{Binding MetadataVersion}"></TextBlock>
+            </StackPanel>
         </Grid>
 
         <!-- Grid bottom row: This section contains the controls for setting the API key for the quotation service -->
@@ -60,50 +111,9 @@
                     <Setter Property="HorizontalAlignment" Value="Stretch"></Setter>
                 </Style>
             </StackPanel.Styles>
-            
+
             <CheckBox Content="{x:Static lang:Resources.UsePhoneData}"
                       IsChecked="{Binding UsePhoneData}" />
-
-            <Label Content="{x:Static lang:Resources.KeyLabel}"></Label>
-            <!-- Grid containing the controls for setting the API key for the quotation service-->
-            <Grid ColumnDefinitions="*, Auto">
-                <TextBox Name="TokenInput" Text="{Binding Key}"
-                         IsEnabled="{Binding  KeyIsInEditMode}"
-                         HorizontalAlignment="Stretch" />
-                <!-- Edit the key -->
-                <Button Grid.Column="1" Classes="decorator"
-                        Command="{Binding EditKeyCommand}"
-                        IsVisible="{Binding !KeyIsInEditMode}">
-                    <StackPanel>
-                        <!--pencil-->
-                        <Label Classes="icon" Content="&#xe3B4;"></Label>
-                    </StackPanel>
-                </Button>
-
-                <!-- Save an updated key value -->
-                <StackPanel Grid.Column="1" Orientation="Horizontal">
-                    <Button Classes="decorator"
-                            Command="{Binding SaveConfigCommand}"
-                            IsVisible="{Binding KeyIsInEditMode}">
-                        <StackPanel>
-                            <!--check mark icon-->
-                            <Label Classes="icon" Content="&#xe182;"></Label>
-                        </StackPanel>
-                    </Button>
-
-                    <!-- Discard changes, restoring previous value -->
-                    <Button Classes="decorator"
-                            Command="{Binding CancelSaveKeyCommand}"
-                            IsVisible="{Binding KeyIsInEditMode}"
-                            BorderBrush="{DynamicResource PrimaryForeground}"
-                            BorderThickness="0 1 1 1">
-                        <StackPanel>
-                            <!-- Label with X icon -->
-                            <Label Classes="icon" Content="&#xe4F6;"></Label>
-                        </StackPanel>
-                    </Button>
-                </StackPanel>
-            </Grid>
 
             <!-- Save Settings Button -->
             <Button Content="{x:Static lang:Resources.BtnSaveSettingsText}"

--- a/Signals/Signals/Views/WatchlistPageView.axaml
+++ b/Signals/Signals/Views/WatchlistPageView.axaml
@@ -7,11 +7,15 @@
 			 xmlns:local="clr-namespace:Signals.Views"
              xmlns:vm="clr-namespace:Signals.ViewModels"
              x:Class="Signals.Views.WatchlistPageView"
-             x:DataType="vm:WatchlistPageViewModel">
+             x:DataType="vm:WatchlistPageViewModel"
+             xmlns:converters="clr-namespace:Signals.Converters">
 
 	<Design.DataContext>
 		<vm:WatchlistPageViewModel />
 	</Design.DataContext>
+	<UserControl.Resources>
+		<converters:LocalTimeConverter x:Key="LocalTimeConverter" />
+	</UserControl.Resources>
 	<!-- 
                                 Command="{Binding $parent[UserControl].((vm:MainViewModel)DataContext).GoToWatchlistDetailCommand, FallbackValue=null}"
                                 Command="{Binding $parent[UserControl].((vm:WatchlistPageViewModel)DataContext).TestCommand, FallbackValue=null}"
@@ -33,7 +37,8 @@
                                 Name="{Binding Name}"
                                 ColourByTrend="{Binding ColourByTrend}"
                                 LatestQuotedPrice="{Binding LatestQuotedPrice}"
-                                WhenLatestQuoteReceived="{Binding WhenLatestQuoteReceived}"
+                                WhenLatestQuoteReceived="{Binding WhenLatestQuoteReceived
+                                , Converter={StaticResource LocalTimeConverter}}"
                                 CurrentDayPercentChange="{Binding CurrentDayPercentChange}" />
 						</StackPanel>
 					</DataTemplate>


### PR DESCRIPTION
The local time converter was applied to all date/time displays.  The text input on the settings page was moved to the top for easier editing. 